### PR TITLE
Fixed capitalization in result for function/bind.md

### DIFF
--- a/function/bind.md
+++ b/function/bind.md
@@ -20,7 +20,7 @@ var day = 'Monday'
 var sayMonday = sayHello.bind(null, day)
 
 sayMonday('Kiko')
-// => 'Hello Kiko, have a good monday'
+// => 'Hello Kiko, have a good Monday'
 ```
 
 The real thing that you need is a *partial function*. The implementation depends of the library that you use but normally it's more faster than `.bind`:


### PR DESCRIPTION
The result for `sayMonday('Kiko')` is currently 
`// => 'Hello Kiko, have a good monday'`

but since `var day = 'Monday'` it should be
`// => 'Hello Kiko, have a good Monday'`