### PR TITLE
Fix typo

### DIFF
--- a/docs/array/arguments.md
+++ b/docs/array/arguments.md
@@ -18,7 +18,7 @@ function spreadOp (...args) {
 }
 ```
 
-If you are in a scenario where is not possible to use `spread operator`, we recommend use the tiny [sliced](https://github.com/aheckmann/sliced) library for make an a copy of the `array`:
+If you are in a scenario where is not possible to use `spread operator`, we recommend use the tiny [sliced](https://github.com/aheckmann/sliced) library for making a copy of the `array`:
 
 ```js
 const sliced = require('sliced')


### PR DESCRIPTION
The current "make an a copy" does not make sense, proposing a change based on what I believe was the original intent.